### PR TITLE
wrong(shorter) allocation of fib.entries[]

### DIFF
--- a/poptrie.c
+++ b/poptrie.c
@@ -99,13 +99,13 @@ poptrie_init(struct poptrie *poptrie, int sz1, int sz0)
     }
 
     /* Prepare the FIB mapping table */
-    poptrie->fib.entries = malloc(sizeof(struct poptrie_fib_entry *)
+    poptrie->fib.entries = malloc(sizeof(struct poptrie_fib_entry)
                                   * POPTRIE_INIT_FIB_SIZE);
     if ( NULL == poptrie->fib.entries ) {
         poptrie_release(poptrie);
         return NULL;
     }
-    memset(poptrie->fib.entries, 0, sizeof(struct poptrie_fib_entry *)
+    memset(poptrie->fib.entries, 0, sizeof(struct poptrie_fib_entry)
            * POPTRIE_INIT_FIB_SIZE);
     poptrie->fib.sz = POPTRIE_INIT_FIB_SIZE;
     /* Insert a NULL entry as the default route */


### PR DESCRIPTION
poptrie->fib.entries is an array of (struct poptrie_fib_entry),
but the initialization allocates it as only an array of
(struct poptrie_fib_entry *), making the array size shorter than expected.

When a random entry (a random entry value) is being added to an empty
poptrie, poptrie_fib_ref() checks the fib.entries through its end,
causes SIGSEGV in the middle of the array (at the end of actual allocated
size).

(struct poptrie_fib_entry *) and (struct poptrie_fib_entry) only differs
in 8 bytes (8 vs 16), so as long as all nexthops can sit within the first
half of the array, and non-existing entry is not searched,
the problem wouldn't show up.