### PR TITLE
bug fix of poptrie6_lookup. patches to test code (to see a failure), and the fix.

### DIFF
--- a/poptrie6.c
+++ b/poptrie6.c
@@ -14,6 +14,8 @@ INDEX(__uint128_t a, int s, int n)
 {
     if ( 0 == ((s) + (n)) ) {
         return 0;
+    } else if ( 128 < ((s) + (n)) ) {
+        return ((a) << (((s) + (n)) - 128)) & ((1ULL << (n)) - 1);
     } else {
         return ((a) >> (128 - ((s) + (n)))) & ((1ULL << (n)) - 1);
     }

--- a/tests/basic6.c
+++ b/tests/basic6.c
@@ -109,6 +109,20 @@ test_lookup(void)
     }
     TEST_PROGRESS();
 
+    /* Route add */
+    addr = IPV6ADDR(0x2001, 0xdb8, 0xaaaa, 0xbbbb, 0, 0, 0, 1);
+    nexthop = (void *)9077;
+    ret = poptrie6_route_add(poptrie, addr, 128, nexthop);
+    if ( ret < 0 ) {
+        /* Failed to add */
+        return -1;
+    }
+    addr = IPV6ADDR(0x2001, 0xdb8, 0xaaaa, 0xbbbb, 0, 0, 0, 1);
+    if ( nexthop != poptrie6_lookup(poptrie, addr) ) {
+        return -1;
+    }
+    TEST_PROGRESS();
+
     /* Route update */
     addr = IPV6ADDR(0x2001, 0xdb8, 0x1, 0x0, 0, 0, 0, 0);
     nexthop = (void *)5678;


### PR DESCRIPTION
This change will make the IPv6 route add test fail. It seems that the
/128 route causes a problem. Not sure if the prefix contents value
is related, but I see sometimes fe80::XXXX/128 works fine.
If we change the /128 to /127, it should pass.